### PR TITLE
Mobile-only: fix landing chip scroll, disable mobile chat autofocus, and make Act1 media landscape

### DIFF
--- a/components/bubbles/Act1FailWidget.tsx
+++ b/components/bubbles/Act1FailWidget.tsx
@@ -60,8 +60,7 @@ export default function Act1FailWidget({ script, lineDelayMs = DEFAULT_DELAY }: 
       </div>
 
       <div className="grid gap-4 p-4 sm:grid-cols-2 sm:gap-6 sm:p-6">
-        {/* square player (fills width like before, uses more vertical space) */}
-        <div className="relative aspect-square overflow-hidden rounded-lg border border-border bg-black">
+        <div className="relative aspect-video overflow-hidden rounded-lg border border-border bg-black sm:aspect-square">
           {showVideo ? (
             <video
               src="/vid/diffusion.mp4"
@@ -96,4 +95,3 @@ export default function Act1FailWidget({ script, lineDelayMs = DEFAULT_DELAY }: 
     </div>
   );
 }
-

--- a/components/chat/ChatConversation.tsx
+++ b/components/chat/ChatConversation.tsx
@@ -69,12 +69,14 @@ export default function ChatConversation({
 }: ChatConversationProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const isInputDisabled = isTyping || isRunningAct1 || isActionLimitReached;
+  const isDesktop =
+    typeof window !== "undefined" ? window.matchMedia("(min-width: 640px)").matches : false;
 
   useEffect(() => {
-    if (!isInputDisabled) {
+    if (isDesktop && !isInputDisabled) {
       inputRef.current?.focus();
     }
-  }, [isInputDisabled]);
+  }, [isDesktop, isInputDisabled]);
 
   function renderMessage(msg: Message) {
     if (msg.role === "system_log") {
@@ -176,7 +178,7 @@ export default function ChatConversation({
                 value={input}
                 onChange={(event) => onInputChange(event.target.value)}
                 maxLength={280}
-                autoFocus
+                autoFocus={isDesktop}
                 placeholder={inputPlaceholder}
                 disabled={isInputDisabled}
                 className="flex-1 bg-transparent px-2 py-1 outline-none placeholder:text-muted-foreground disabled:opacity-50"

--- a/components/chat/ChatLanding.tsx
+++ b/components/chat/ChatLanding.tsx
@@ -84,7 +84,7 @@ export default function ChatLanding({
                 </div>
               </form>
 
-              <div className="chip-scroll-hint mx-auto flex w-full flex-nowrap items-center justify-center gap-2 overflow-x-auto px-0.5 pt-1 pb-1 no-scrollbar">
+              <div className="chip-scroll-hint mx-auto flex w-full flex-nowrap items-center justify-start gap-2 overflow-x-auto px-3 pt-1 pb-1 no-scrollbar sm:justify-center sm:px-0.5">
                 {LANDING_SUGGESTIONS.map((chip) => (
                   <button
                     key={chip}


### PR DESCRIPTION
### Motivation
- Fix the landing-page suggestion chip rail on small screens so the left-most chip is not clipped and all chips are reachable by horizontal scroll.  
- Prevent the main chat input from stealing focus on mobile to avoid unexpected keyboard popups.  
- Reduce vertical space used by the Act1 fail widget on phones by making its media area a landscape rectangle.

### Description
- Updated the landing chips container in `components/chat/ChatLanding.tsx` to align chips from the left on mobile and add horizontal padding while preserving centered layout on `sm` and up.  
- Updated `components/chat/ChatConversation.tsx` to detect desktop via `window.matchMedia("(min-width: 640px)")` and only run the imperative focus and `autoFocus` when on desktop.  
- Updated `components/bubbles/Act1FailWidget.tsx` to use `aspect-video` on mobile and `sm:aspect-square` on larger viewports so the fake-generation video / oopsie screen is landscape on phones.

### Testing
- Ran `npm run build`, which failed in this environment because the prebuild video catalog fetch cannot reach the network (`ENETUNREACH`).  
- Ran `npx tsc --noEmit`, which failed in this environment due to missing installed project dependencies and type declarations (e.g., `react`, `next`, `@types/node`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2ee40058832da5b0de17c18d1bed)