### PR TITLE
[codex] Smooth video playback and lighter background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 
 import { Suspense } from "react";
-import LiquidEtherBackground from "@/components/backgrounds/LiquidEtherBackground";
+import PerformanceAwareBackground from "@/components/backgrounds/PerformanceAwareBackground";
 
 export default function RootLayout({
   children,
@@ -12,7 +12,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="min-h-screen bg-background text-foreground">
         <Suspense fallback={null}>
-          <LiquidEtherBackground deferUntilInteraction />
+          <PerformanceAwareBackground />
         </Suspense>
         {/* Let pages decide about headers / chrome */}
         <main className="relative z-10 min-h-screen">{children}</main>

--- a/components/VideoCard.tsx
+++ b/components/VideoCard.tsx
@@ -7,7 +7,7 @@ type Selectable = { onSelect: (video: VideoItem) => void; href?: never };
 type Linkable  = { href: string; onSelect?: never };
 type Props = { video: VideoItem } & (Selectable | Linkable);
 
-// Build better YouTube thumbnails (maxres → sd → hq → mq fallback)
+// Build lightweight YouTube thumbnails (sd -> hq -> mq fallback).
 function buildThumbs(thumbnail: string) {
   try {
     const u = new URL(thumbnail);
@@ -27,16 +27,15 @@ function buildThumbs(thumbnail: string) {
     }
     const id = m[1];
     const base = `https://img.youtube.com/vi/${id}`;
-    const maxres = `${base}/maxresdefault.jpg`;  // 1280x720 (may 404)
     const sd     = `${base}/sddefault.jpg`;      // 640x480
     const hq     = `${base}/hqdefault.jpg`;      // 480x360
     const mq     = `${base}/mqdefault.jpg`;      // 320x180
 
     return {
-      // Start safe (hq), but advertise larger versions via srcSet
+      // Avoid maxresdefault here: it often 404s and is too heavy for grid cards.
       src: hq,
-      srcSet: `${mq} 320w, ${hq} 480w, ${sd} 640w, ${maxres} 1280w`,
-      sizes: "(min-width:1024px) 960px, (min-width:640px) 560px, 100vw",
+      srcSet: `${mq} 320w, ${hq} 480w, ${sd} 640w`,
+      sizes: "(min-width:1024px) 520px, (min-width:640px) 50vw, 100vw",
       // Fallback chain for 404s on chosen src/srcset candidate
       fallbacks: [sd, hq, mq],
     };
@@ -48,7 +47,7 @@ function buildThumbs(thumbnail: string) {
 function CardInner({ video }: { video: VideoItem }) {
   const thumbs = buildThumbs(video.thumbnail);
 
-  // Simple 404 downgrade: try sd → hq → mq
+  // Simple 404 downgrade: try sd -> hq -> mq.
   function handleImgError(e: React.SyntheticEvent<HTMLImageElement>) {
     const el = e.currentTarget;
     const list = (el.dataset.fallbacks || "").split("|").filter(Boolean);
@@ -63,7 +62,7 @@ function CardInner({ video }: { video: VideoItem }) {
   }
 
   return (
-    <div className="relative w-full overflow-hidden rounded-xl border border-border transition-shadow group">
+    <div className="relative w-full overflow-hidden rounded-xl border border-border transition-shadow group [content-visibility:auto] [contain-intrinsic-size:320px_180px]">
       {/* Thumbnail */}
       <div className="relative aspect-video overflow-hidden">
         <img
@@ -75,7 +74,8 @@ function CardInner({ video }: { video: VideoItem }) {
           alt={video.title}
           data-fallbacks={thumbs.fallbacks.join("|")}
           onError={handleImgError}
-          className="h-full w-full object-cover transition-transform duration-300 will-change-transform group-hover:scale-[1.02]"
+          draggable={false}
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
         />
 
         {/* Veil (very light, theme-aware) */}

--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -1,11 +1,12 @@
 // /components/VideoPlayer.tsx
 "use client";
 
-import { useCallback, useEffect, useId, useRef } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 type Props = {
   url: string; // Bunny iframe URL or YouTube URL
   title?: string;
+  thumbnail?: string | null;
   className?: string;
   autoplay?: boolean;
   playerId?: string;
@@ -45,6 +46,7 @@ function extractYouTubeId(url: string): string | null {
 export default function VideoPlayer({
   url,
   title,
+  thumbnail,
   className,
   autoplay,
   playerId,
@@ -64,6 +66,8 @@ export default function VideoPlayer({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const bunnyPlayerRef = useRef<any | null>(null);
+  const [isActivated, setIsActivated] = useState(Boolean(autoplay));
+  const [isNearViewport, setIsNearViewport] = useState(Boolean(autoplay));
 
   // Internal refs for Bunny player state
   const durationRef = useRef<number | null>(null);
@@ -83,15 +87,56 @@ export default function VideoPlayer({
   const SCRUB_SUPPRESS_MS = 800;
 
   const isBunny = url.includes("iframe.mediadelivery.net");
+  const youTubeId = isBunny ? null : extractYouTubeId(url);
+
+  let src: string | null = null;
+  if (isBunny) {
+    src = url;
+  } else if (youTubeId) {
+    const params = new URLSearchParams();
+    if (autoplay) {
+      params.set("autoplay", "1");
+      params.set("mute", "1");
+    }
+    params.set("enablejsapi", "1");
+    params.set("playsinline", "1");
+    params.set("rel", "0");
+    const query = params.toString();
+    src = `https://www.youtube.com/embed/${youTubeId}${query ? `?${query}` : ""}`;
+  }
+
+  const posterSrc = thumbnail ?? (youTubeId ? `https://img.youtube.com/vi/${youTubeId}/hqdefault.jpg` : null);
+  const shouldRenderIframe = Boolean(src && isActivated && isNearViewport);
 
   const emitGlobalPlay = useCallback(() => {
     if (typeof window === "undefined") return;
     window.dispatchEvent(
       new CustomEvent("mimsy:video:play", {
         detail: { playerId: resolvedPlayerId },
-      })
+      }),
     );
   }, [resolvedPlayerId]);
+
+  const emitGlobalPlayingChange = useCallback(
+    (isPlaying: boolean) => {
+      if (typeof window === "undefined") return;
+      window.dispatchEvent(
+        new CustomEvent("mimsy:video:playing-change", {
+          detail: { playerId: resolvedPlayerId, isPlaying },
+        }),
+      );
+    },
+    [resolvedPlayerId],
+  );
+
+  const setPlayingState = useCallback(
+    (isPlaying: boolean) => {
+      isPlayingRef.current = isPlaying;
+      onPlayingChange?.(isPlaying);
+      emitGlobalPlayingChange(isPlaying);
+    },
+    [emitGlobalPlayingChange, onPlayingChange],
+  );
 
   const emitDebugEvent = useCallback(
     (type: string, data?: Record<string, unknown>) => {
@@ -106,31 +151,11 @@ export default function VideoPlayer({
             url,
             ...data,
           },
-        })
+        }),
       );
     },
-    [isBunny, resolvedPlayerId, title, url]
+    [isBunny, resolvedPlayerId, title, url],
   );
-
-  // Build src
-  let src: string | null = null;
-
-  if (isBunny) {
-    src = url;
-    // If you want autoplay for Bunny later, you can add query params here.
-    // if (autoplay) src += (url.includes("?") ? "&" : "?") + "autoplay=1&muted=1";
-  } else {
-    const id = extractYouTubeId(url);
-    if (!id) return null;
-    const params = new URLSearchParams();
-    if (autoplay) {
-      params.set("autoplay", "1");
-      params.set("mute", "1");
-    }
-    params.set("enablejsapi", "1");
-    const query = params.toString();
-    src = `https://www.youtube.com/embed/${id}${query ? `?${query}` : ""}`;
-  }
 
   // Reset internal refs when URL changes
   useEffect(() => {
@@ -147,11 +172,34 @@ export default function VideoPlayer({
     nearEndRef.current = false;
     autoPausedRef.current = false;
     scrubbedAtRef.current = null;
-    onPlayingChange?.(false);
-  }, [url, onPlayingChange]);
+    setIsActivated(Boolean(autoplay));
+    setPlayingState(false);
+  }, [autoplay, setPlayingState, url]);
 
-  // Load Bunny player.js and wire events
   useEffect(() => {
+    if (typeof window === "undefined") return;
+    const target = containerRef.current;
+    if (!target) return;
+    if (!("IntersectionObserver" in window)) {
+      setIsNearViewport(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        setIsNearViewport(Boolean(entry?.isIntersecting));
+      },
+      { rootMargin: "900px 0px", threshold: 0 },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
+  // Load Bunny player.js and wire events only while the iframe is actually mounted.
+  useEffect(() => {
+    if (!shouldRenderIframe) return;
     if (!isBunny) return;
     if (typeof window === "undefined") return;
 
@@ -164,21 +212,20 @@ export default function VideoPlayer({
           return;
         }
         const existing = document.querySelector<HTMLScriptElement>(
-          'script[src="//assets.mediadelivery.net/playerjs/playerjs-latest.min.js"]'
+          'script[src="https://assets.mediadelivery.net/playerjs/playerjs-latest.min.js"], script[src="//assets.mediadelivery.net/playerjs/playerjs-latest.min.js"]',
         );
         if (existing) {
           existing.addEventListener("load", () => resolve(), { once: true });
           return;
         }
         const script = document.createElement("script");
-        script.src = "//assets.mediadelivery.net/playerjs/playerjs-latest.min.js";
+        script.src = "https://assets.mediadelivery.net/playerjs/playerjs-latest.min.js";
         script.async = true;
         script.onload = () => resolve();
         document.body.appendChild(script);
       });
 
     let player: any | null = null;
-
     let cancelled = false;
 
     ensureScript().then(() => {
@@ -192,11 +239,10 @@ export default function VideoPlayer({
       const handlePlayOrPlaying = () => {
         const wasPlaying = isPlayingRef.current;
         hasStartedRef.current = true;
-        isPlayingRef.current = true;
         endedRef.current = false;
         autoPausedRef.current = false;
         emitGlobalPlay();
-        onPlayingChange?.(true);
+        setPlayingState(true);
         const scrubbedAt = scrubbedAtRef.current;
         const suppressPlay =
           typeof scrubbedAt === "number" && Date.now() - scrubbedAt < SCRUB_SUPPRESS_MS;
@@ -206,8 +252,7 @@ export default function VideoPlayer({
       };
 
       const handlePause = () => {
-        isPlayingRef.current = false;
-        onPlayingChange?.(false);
+        setPlayingState(false);
 
         // "stopped early" = paused after playing started, before end
         if (autoPausedRef.current) {
@@ -227,9 +272,8 @@ export default function VideoPlayer({
       };
 
       const handleEnded = () => {
-        isPlayingRef.current = false;
         endedRef.current = true;
-        onPlayingChange?.(false);
+        setPlayingState(false);
         onEnded?.();
         emitDebugEvent("ended");
       };
@@ -238,7 +282,6 @@ export default function VideoPlayer({
         if (!data || typeof data.seconds !== "number") return;
         const seconds = data.seconds as number;
 
-        // Track duration if provided
         if (typeof data.duration === "number" && data.duration > 0) {
           durationRef.current = data.duration;
         }
@@ -274,14 +317,12 @@ export default function VideoPlayer({
           onPlayed5s?.();
         }
 
-        // Event: played at least 10s (fire once)
         if (!played10Ref.current && seconds >= 10) {
           played10Ref.current = true;
           onPlayed10s?.();
           emitDebugEvent("played-10s");
         }
 
-        // Event: reached midpoint (fire once)
         if (
           duration &&
           duration > 0 &&
@@ -300,7 +341,6 @@ export default function VideoPlayer({
           onReachedNearEnd?.();
         }
 
-        // Poll mute state (Bunny doesn't emit mute events)
         if (typeof player.getMuted === "function") {
           try {
             player.getMuted((muted: boolean) => {
@@ -319,14 +359,12 @@ export default function VideoPlayer({
         }
       };
 
-      // Attach listeners
       player.on("play", handlePlayOrPlaying);
       player.on("playing", handlePlayOrPlaying);
       player.on("pause", handlePause);
       player.on("ended", handleEnded);
       player.on("timeupdate", handleTimeUpdate);
 
-      // On ready, detect autoplay & initial mute
       player.on("ready", () => {
         if (typeof player.getPaused === "function") {
           try {
@@ -355,6 +393,7 @@ export default function VideoPlayer({
 
     return () => {
       cancelled = true;
+      setPlayingState(false);
       try {
         bunnyPlayerRef.current = null;
         if (player && typeof player.destroy === "function") {
@@ -365,9 +404,9 @@ export default function VideoPlayer({
       }
     };
   }, [
+    shouldRenderIframe,
     isBunny,
     url,
-    onPlayingChange,
     onPlayed5s,
     onPlayed10s,
     onReachedMidpoint,
@@ -378,9 +417,12 @@ export default function VideoPlayer({
     onScrubForward,
     onScrubBackward,
     emitGlobalPlay,
+    emitDebugEvent,
+    setPlayingState,
   ]);
 
   useEffect(() => {
+    if (!shouldRenderIframe) return;
     if (typeof window === "undefined") return;
 
     const handleGlobalPlay = (event: Event) => {
@@ -402,7 +444,7 @@ export default function VideoPlayer({
             func: "pauseVideo",
             args: "",
           }),
-          "*"
+          "*",
         );
       }
     };
@@ -411,9 +453,10 @@ export default function VideoPlayer({
     return () => {
       window.removeEventListener("mimsy:video:play", handleGlobalPlay);
     };
-  }, [isBunny, resolvedPlayerId]);
+  }, [isBunny, resolvedPlayerId, shouldRenderIframe]);
 
   useEffect(() => {
+    if (!shouldRenderIframe) return;
     if (isBunny) return;
     if (typeof window === "undefined") return;
 
@@ -438,14 +481,17 @@ export default function VideoPlayer({
       try {
         const data = JSON.parse(event.data);
         if (data?.event === "onStateChange" && data?.info === 1) {
+          hasStartedRef.current = true;
+          endedRef.current = false;
           emitGlobalPlay();
-          onPlayingChange?.(true);
+          setPlayingState(true);
         }
         if (data?.event === "onStateChange" && data?.info === 2) {
-          onPlayingChange?.(false);
+          setPlayingState(false);
         }
         if (data?.event === "onStateChange" && data?.info === 0) {
-          onPlayingChange?.(false);
+          endedRef.current = true;
+          setPlayingState(false);
           onEnded?.();
         }
       } catch {
@@ -456,10 +502,12 @@ export default function VideoPlayer({
     window.addEventListener("message", handleMessage);
     return () => {
       window.removeEventListener("message", handleMessage);
+      setPlayingState(false);
     };
-  }, [emitGlobalPlay, isBunny, onEnded, onPlayingChange, resolvedPlayerId]);
+  }, [emitGlobalPlay, isBunny, onEnded, resolvedPlayerId, setPlayingState, shouldRenderIframe]);
 
   useEffect(() => {
+    if (!shouldRenderIframe) return;
     if (typeof window === "undefined") return;
     const target = containerRef.current;
     if (!target) return;
@@ -485,31 +533,63 @@ export default function VideoPlayer({
               func: "pauseVideo",
               args: "",
             }),
-            "*"
+            "*",
           );
         }
       },
-      { threshold: [0, 0.2, 1] }
+      { threshold: [0, 0.2, 1] },
     );
 
     observer.observe(target);
     return () => {
       observer.disconnect();
     };
-  }, [isBunny]);
+  }, [isBunny, shouldRenderIframe]);
+
+  if (!src) return null;
 
   return (
     <div ref={containerRef} className={`w-full ${className ?? ""}`}>
-      <div className="aspect-video overflow-hidden rounded-xl shadow">
-        <iframe
-          ref={iframeRef}
-          src={src ?? undefined}
-          title={title ?? "Video player"}
-          className="w-full h-full"
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowFullScreen
-        />
+      <div className="aspect-video overflow-hidden rounded-xl bg-black shadow">
+        {shouldRenderIframe ? (
+          <iframe
+            ref={iframeRef}
+            src={src}
+            title={title ?? "Video player"}
+            className="h-full w-full"
+            frameBorder="0"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setIsActivated(true);
+              setIsNearViewport(true);
+            }}
+            className="group relative flex h-full w-full items-center justify-center overflow-hidden bg-black text-white focus:outline-none focus:ring-2 focus:ring-[hsl(var(--ring))] focus:ring-offset-2 focus:ring-offset-[hsl(var(--background))]"
+            aria-label={`Load video${title ? `: ${title}` : ""}`}
+          >
+            {posterSrc ? (
+              <img
+                src={posterSrc}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="absolute inset-0 h-full w-full object-cover opacity-85 transition duration-200 group-hover:scale-[1.01] group-hover:opacity-95"
+              />
+            ) : null}
+            <span className="absolute inset-0 bg-black/25" aria-hidden="true" />
+            <span className="relative flex h-14 w-14 items-center justify-center rounded-full bg-white/90 text-black shadow-lg transition duration-200 group-hover:scale-105">
+              <span
+                className="ml-1 h-0 w-0 border-y-[10px] border-l-[16px] border-y-transparent border-l-black"
+                aria-hidden="true"
+              />
+            </span>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/components/VideoSection.tsx
+++ b/components/VideoSection.tsx
@@ -11,6 +11,7 @@ export default function VideoSection({ video }: Props) {
         <VideoPlayer
           url={video.url}
           title={video.title}
+          thumbnail={video.thumbnail}
           className="w-full rounded-lg"
         />
       </div>

--- a/components/backgrounds/PerformanceAwareBackground.tsx
+++ b/components/backgrounds/PerformanceAwareBackground.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import LiquidEtherBackground from "@/components/backgrounds/LiquidEtherBackground";
+
+const LazyLiquidEther = lazy(() => import("@/components/backgrounds/LiquidEther"));
+
+type NavigatorWithPerformanceHints = Navigator & {
+  deviceMemory?: number;
+  connection?: {
+    effectiveType?: string;
+    saveData?: boolean;
+  };
+};
+
+function getShouldDisableLiquid() {
+  if (typeof window === "undefined") return true;
+
+  const navigatorWithHints = window.navigator as NavigatorWithPerformanceHints;
+  const connection = navigatorWithHints.connection;
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const isMobile =
+    window.matchMedia("(max-width: 767px)").matches || window.matchMedia("(pointer: coarse)").matches;
+  const saveData = Boolean(connection?.saveData);
+  const slowConnection = /(^|-)2g$/.test(connection?.effectiveType ?? "");
+  const constrainedMemory =
+    typeof navigatorWithHints.deviceMemory === "number" && navigatorWithHints.deviceMemory <= 4;
+  const constrainedCpu =
+    typeof navigator.hardwareConcurrency === "number" && navigator.hardwareConcurrency <= 4;
+
+  return prefersReducedMotion || isMobile || saveData || slowConnection || constrainedMemory || constrainedCpu;
+}
+
+export default function PerformanceAwareBackground() {
+  const [isDesignMode, setIsDesignMode] = useState(false);
+  const [isLiquidReady, setIsLiquidReady] = useState(false);
+  const [shouldDisableLiquid, setShouldDisableLiquid] = useState(true);
+  const [isVideoPlaying, setIsVideoPlaying] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const sync = () => {
+      const params = new URLSearchParams(window.location.search);
+      setIsDesignMode(params.get("mode") === "design");
+      setShouldDisableLiquid(getShouldDisableLiquid());
+    };
+
+    sync();
+    window.addEventListener("resize", sync);
+    window.addEventListener("popstate", sync);
+    return () => {
+      window.removeEventListener("resize", sync);
+      window.removeEventListener("popstate", sync);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isDesignMode || shouldDisableLiquid) {
+      setIsLiquidReady(false);
+      return;
+    }
+
+    const markReady = () => setIsLiquidReady(true);
+    const fallbackId = window.setTimeout(markReady, 2200);
+    const listenerOptions: AddEventListenerOptions = { once: true, passive: true };
+
+    window.addEventListener("pointerdown", markReady, listenerOptions);
+    window.addEventListener("keydown", markReady, { once: true });
+    window.addEventListener("wheel", markReady, listenerOptions);
+    window.addEventListener("touchstart", markReady, listenerOptions);
+
+    return () => {
+      window.clearTimeout(fallbackId);
+      window.removeEventListener("pointerdown", markReady);
+      window.removeEventListener("keydown", markReady);
+      window.removeEventListener("wheel", markReady);
+      window.removeEventListener("touchstart", markReady);
+    };
+  }, [isDesignMode, shouldDisableLiquid]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const activePlayers = new Set<string>();
+    const handleVideoPlayingChange = (event: Event) => {
+      const customEvent = event as CustomEvent<{ playerId?: string; isPlaying?: boolean }>;
+      const playerId = customEvent.detail?.playerId;
+      if (!playerId) return;
+
+      if (customEvent.detail?.isPlaying) {
+        activePlayers.add(playerId);
+      } else {
+        activePlayers.delete(playerId);
+      }
+
+      setIsVideoPlaying(activePlayers.size > 0);
+    };
+
+    window.addEventListener("mimsy:video:playing-change", handleVideoPlayingChange);
+    return () => {
+      window.removeEventListener("mimsy:video:playing-change", handleVideoPlayingChange);
+    };
+  }, []);
+
+  const shouldRenderLiquid = !isDesignMode && isLiquidReady && !shouldDisableLiquid && !isVideoPlaying;
+
+  const staticOpacity = useMemo(() => {
+    if (isVideoPlaying || shouldDisableLiquid) return 0.72;
+    return shouldRenderLiquid ? 0.35 : 0.6;
+  }, [isVideoPlaying, shouldDisableLiquid, shouldRenderLiquid]);
+
+  if (isDesignMode) {
+    return (
+      <Suspense fallback={null}>
+        <LiquidEtherBackground deferUntilInteraction />
+      </Suspense>
+    );
+  }
+
+  return (
+    <div aria-hidden="true" className="pointer-events-none fixed inset-0 z-0">
+      <div
+        className="absolute inset-0 transition-opacity duration-500"
+        style={{
+          background:
+            "radial-gradient(circle at 18% 18%, rgba(131, 210, 236, 0.22), transparent 32%), radial-gradient(circle at 78% 24%, rgba(249, 190, 247, 0.2), transparent 30%), radial-gradient(circle at 54% 78%, rgba(236, 19, 218, 0.12), transparent 34%)",
+          opacity: staticOpacity,
+        }}
+      />
+      {shouldRenderLiquid ? (
+        <div className="absolute inset-0">
+          <Suspense fallback={null}>
+            <LazyLiquidEther
+              mouseForce={3}
+              cursorSize={48}
+              isViscous={false}
+              viscous={20}
+              iterationsViscous={0}
+              iterationsPoisson={8}
+              BFECC={false}
+              colors={["#83d2ec", "#f9bef7", "#ec13da"]}
+              autoDemo={false}
+              autoSpeed={0.35}
+              autoIntensity={0}
+              isBounce={false}
+              resolution={0.16}
+            />
+          </Suspense>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/bubbles/HeroPlayerBubble.tsx
+++ b/components/bubbles/HeroPlayerBubble.tsx
@@ -98,6 +98,7 @@ export default function HeroPlayerBubble({
       <VideoPlayer
         url={video.url}
         title={video.title}
+        thumbnail={video.thumbnail}
         className="bg-black"
         autoplay
         onPlayingChange={handlePlayingChange}


### PR DESCRIPTION
## What changed

This makes the video experience lighter and smoother on slower computers and browsers.

- Video cards now request smaller thumbnail sizes and avoid the often-heavy YouTube max-resolution thumbnail candidate.
- Video cards use browser rendering containment so large galleries do less work while scrolling.
- Video players now mount the third-party iframe only when the player is active and close enough to the viewport.
- Offscreen/inactive players are cleaned up so old chat videos do not keep consuming browser resources.
- Video sections and hero video bubbles now pass thumbnails into the player so unloaded players can show a poster instead of a blank area.
- The animated background now uses a new performance-aware wrapper.
- The liquid WebGL effect is much lighter in normal browsing: lower resolution, no viscous pass, fewer pressure iterations, no auto movement.
- When any video starts playing, the WebGL background is removed and only the static soft gradient remains.
- On mobile, reduced-motion, save-data, slow network, low-memory, or low-core devices, the WebGL background stays disabled and the static gradient is used.
- `?mode=design` still loads the original design-mode background controls.

## Why

Your `No-background` branch test showed that videos play smoothly without the animated background, so the background was competing with video playback for browser/GPU resources. This PR keeps the visual background feel while preventing it from fighting the video player.

## Validation

- Ran `tsc --noEmit` successfully after the background changes.
- Earlier Next production build compilation completed successfully, then the local Windows sandbox blocked a later child process with `spawn EPERM`, so the full build could not finish in this environment.

## Manual steps

No code setup is needed. Please test the preview for this PR/branch: `codex/smooth-video-playback`. If videos feel smooth, merge this PR into `main`. If your site is connected to Vercel/Netlify/GitHub Pages, it should redeploy automatically after the merge; otherwise use your normal deploy button/process.